### PR TITLE
release candidate; resolves a CVE

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,7 @@
 Revision history for Perl extension Catalyst::Plugin::Authentication
 
+    - fix password comparison to avoid timing attacks (CVE TBA)
+
 0.10024 - 2024-10-16
     - update to prefer modern Catalyst APIs
     - silence expected warnings in tests

--- a/lib/Catalyst/Authentication/Credential/Password.pm
+++ b/lib/Catalyst/Authentication/Credential/Password.pm
@@ -69,9 +69,9 @@ sub check_password {
             # FIXME - Should we warn in the $storedpassword undef case,
             #         as the user probably fluffed the config?
             return unless defined $storedpassword;
-            return $password eq $storedpassword;
+            return _secure_compare($password, $storedpassword);
         } elsif ($self->_config->{'password_type'} eq 'crypted') {
-            return $storedpassword eq crypt( $password, $storedpassword );
+            return _secure_compare(crypt($password, $storedpassword), $storedpassword);
         } elsif ($self->_config->{'password_type'} eq 'salted_hash') {
             require Crypt::SaltedHash;
             my $salt_len = $self->_config->{'password_salt_len'} ? $self->_config->{'password_salt_len'} : 0;
@@ -86,12 +86,24 @@ sub check_password {
 
              my $computed    = $d->clone()->digest;
              my $b64computed = $d->clone()->b64digest;
-             return ( ( $computed eq $storedpassword )
-                   || ( unpack( "H*", $computed ) eq $storedpassword )
-                   || ( $b64computed eq $storedpassword)
-                   || ( $b64computed.'=' eq $storedpassword) );
+             return ( ( _secure_compare($computed, $storedpassword) )
+                   || ( _secure_compare(unpack("H*", $computed), $storedpassword) )
+                   || ( _secure_compare($b64computed, $storedpassword) )
+                   || ( _secure_compare($b64computed.'=', $storedpassword)) );
         }
     }
+}
+
+# Constant time comparison algorithm to prevent timing attacks. The secret
+# string should be the second argument, to avoid leaking information about
+# the length of the string.
+# (lifted shamelessly from Mojo::Util 9.45)
+sub _secure_compare {
+  my ($one, $two) = @_;
+  my $r = length $one != length $two;
+  $two = $one if $r;
+  $r |= ord(substr $one, $_) ^ ord(substr $two, $_) for 0 .. length($one) - 1;
+  return $r == 0;
 }
 
 __PACKAGE__;

--- a/lib/Catalyst/Plugin/Authentication.pm
+++ b/lib/Catalyst/Plugin/Authentication.pm
@@ -9,7 +9,7 @@ with 'MooseX::Emulate::Class::Accessor::Fast';
 
 __PACKAGE__->mk_accessors(qw/_user/);
 
-our $VERSION = '0.10024';
+our $VERSION = '0.10_025';
 
 sub set_authenticated {
     my ( $c, $user, $realmname ) = @_;

--- a/t/store_nopassord.t
+++ b/t/store_nopassord.t
@@ -3,6 +3,5 @@ use warnings;
 
 use Test::More tests => 1;
 
-use_ok 'Catalyst::Authentication::Credential::NoPassword',
-  "Catalyst::Authentication::Credential::NoPassword at right spot";
+use_ok 'Catalyst::Authentication::Credential::NoPassword';
 


### PR DESCRIPTION
The CVE (not yet announced) involves a timing attack with string comparisons of the password.  I used the implementation from Mojolicious so it should be suitable.

I will release this as trial if it's good and then go stable in a week or so.