### PR TITLE
rotate session id after authentication

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for Perl extension Catalyst::Plugin::Authentication
 
+    - When used with Catalyst::Plugin::Session, rotate the session id after a
+      successful login to avoid session fixation attacks (CVE-2009-10007).
+
 0.10026 - 2026-05-21
     - no changes since 0.10_025
 

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -34,7 +34,7 @@ my %META = (
         'Test::Pod::Coverage' => '1.04',
         'Test::NoTabs' => 0,
         'Test::EOL' => 0,
-        'Catalyst::Plugin::Session' => '0.10',
+        'Catalyst::Plugin::Session' => '0.25',
         'Catalyst::Plugin::Session::State::Cookie' => 0,
         'Digest::SHA' => 0,
       },

--- a/lib/Catalyst/Authentication/Realm.pm
+++ b/lib/Catalyst/Authentication/Realm.pm
@@ -26,6 +26,14 @@ sub new {
         }
     }
 
+    if (!exists($self->config->{'rotate_session_id'})) {
+        if (exists($app->config->{'Plugin::Authentication'}{'rotate_session_id'})) {
+            $self->config->{'rotate_session_id'} = $app->config->{'Plugin::Authentication'}{'rotate_session_id'};
+        } else {
+            $self->config->{'rotate_session_id'} = 1;
+        }
+    }
+
     $app->log->debug("Setting up auth realm $realmname") if $app->debug;
 
     $self->setup_store($app);
@@ -238,6 +246,13 @@ sub persist_user {
         and $self->config->{'use_session'}
         and $user->supports("session")
     ) {
+        if (
+            $self->config->{rotate_session_id}
+            and $c->session_is_valid
+        ) {
+            $c->change_session_id;
+        }
+
         $c->session->{__user_realm} = $self->name;
 
         # we want to ask the store for a user prepared for the session.

--- a/lib/Catalyst/Authentication/Realm.pm
+++ b/lib/Catalyst/Authentication/Realm.pm
@@ -28,6 +28,18 @@ sub new {
 
     $app->log->debug("Setting up auth realm $realmname") if $app->debug;
 
+    $self->setup_store($app);
+    $self->setup_credential($app);
+
+    return $self;
+}
+
+sub setup_store {
+    my ($self, $app) = @_;
+
+    my $config = $self->config;
+    my $realmname = $self->name;
+
     # use the Null store as a default - Don't complain if the realm class is being overridden,
     # as the new realm may behave differently.
     if( ! exists($config->{store}{class}) ) {
@@ -44,6 +56,55 @@ sub new {
         '' => 'Catalyst::Authentication::Store::',
         '+' => '',
     }, $storeclass);
+
+    try {
+        Catalyst::Utils::ensure_class_loaded( $storeclass );
+    }
+    catch {
+        # If the file is missing, then try the old-style fallback,
+        # but re-throw anything else for the user to deal with.
+        die $_ unless /^Can't locate/;
+        $app->log->warn( qq(Store class "$storeclass" not found, trying deprecated ::Plugin:: style naming. ) );
+        my $origstoreclass = $storeclass;
+        $storeclass =~ s/Catalyst::Authentication/Catalyst::Plugin::Authentication/;
+        try { Catalyst::Utils::ensure_class_loaded( $storeclass ); }
+        catch {
+            # Likewise this croak is useful if the second exception is also "not found",
+            # but would be confusing if it's anything else.
+            die $_ unless /^Can't locate/;
+            Carp::croak "Unable to load store class, " . $origstoreclass . " OR " . $storeclass .
+                        " in realm " . $self->name;
+        };
+    };
+
+    # BACKWARDS COMPATIBILITY - if the store class does not define find_user, we define it in terms
+    # of get_user and add it to the class.  this is because the auth routines use find_user,
+    # and rely on it being present. (this avoids per-call checks)
+    if (!$storeclass->can('find_user')) {
+        no strict 'refs';
+        *{"${storeclass}::find_user"} = sub {
+            my ($self, $info) = @_;
+            my @rest = @{$info->{rest}} if exists($info->{rest});
+            $self->get_user($info->{id}, @rest);
+        };
+    }
+
+    ## a little cruft to stay compatible with some poorly written stores / credentials
+    ## we'll remove this soon.
+    if ($storeclass->can('new')) {
+        $self->store($storeclass->new($config->{'store'}, $app, $self));
+    }
+    else {
+        $app->log->error("THIS IS DEPRECATED: $storeclass has no new() method - Attempting to use uninstantiated");
+        $self->store($storeclass);
+    }
+    return;
+}
+
+sub setup_credential {
+    my ($self, $app) = @_;
+
+    my $config = $self->config;
 
     # a little niceness - since most systems seem to use the password credential class,
     # if no credential class is specified we use password.
@@ -87,47 +148,6 @@ sub new {
         };
     };
 
-    try {
-        Catalyst::Utils::ensure_class_loaded( $storeclass );
-    }
-    catch {
-        # If the file is missing, then try the old-style fallback,
-        # but re-throw anything else for the user to deal with.
-        die $_ unless /^Can't locate/;
-        $app->log->warn( qq(Store class "$storeclass" not found, trying deprecated ::Plugin:: style naming. ) );
-        my $origstoreclass = $storeclass;
-        $storeclass =~ s/Catalyst::Authentication/Catalyst::Plugin::Authentication/;
-        try { Catalyst::Utils::ensure_class_loaded( $storeclass ); }
-        catch {
-            # Likewise this croak is useful if the second exception is also "not found",
-            # but would be confusing if it's anything else.
-            die $_ unless /^Can't locate/;
-            Carp::croak "Unable to load store class, " . $origstoreclass . " OR " . $storeclass .
-                        " in realm " . $self->name;
-        };
-    };
-
-    # BACKWARDS COMPATIBILITY - if the store class does not define find_user, we define it in terms
-    # of get_user and add it to the class.  this is because the auth routines use find_user,
-    # and rely on it being present. (this avoids per-call checks)
-    if (!$storeclass->can('find_user')) {
-        no strict 'refs';
-        *{"${storeclass}::find_user"} = sub {
-            my ($self, $info) = @_;
-            my @rest = @{$info->{rest}} if exists($info->{rest});
-            $self->get_user($info->{id}, @rest);
-        };
-    }
-
-    ## a little cruft to stay compatible with some poorly written stores / credentials
-    ## we'll remove this soon.
-    if ($storeclass->can('new')) {
-        $self->store($storeclass->new($config->{'store'}, $app, $self));
-    }
-    else {
-        $app->log->error("THIS IS DEPRECATED: $storeclass has no new() method - Attempting to use uninstantiated");
-        $self->store($storeclass);
-    }
     if ($credentialclass->can('new')) {
         $self->credential($credentialclass->new($config->{'credential'}, $app, $self));
     }
@@ -136,7 +156,7 @@ sub new {
         $self->credential($credentialclass);
     }
 
-    return $self;
+    return;
 }
 
 sub find_user {

--- a/lib/Catalyst/Authentication/Realm/Compatibility.pm
+++ b/lib/Catalyst/Authentication/Realm/Compatibility.pm
@@ -8,17 +8,8 @@ use base qw/Catalyst::Authentication::Realm/;
 ## very funky - the problem here is that we can't do real realm initialization
 ## but we need a real realm object to function.  So - we kinda fake it - we
 ## create an empty object -
-sub new {
-    my ($class, $realmname, $config, $app) = @_;
-
-    my $self = { config => $config };
-    bless $self, $class;
-
-    $self->config->{'use_session'} = $app->config->{'Plugin::Authentication'}{'use_session'} || '1';
-    $self->name($realmname);
-
-    return $self;
-}
+sub setup_store {}
+sub setup_credential {}
 
 __PACKAGE__;
 

--- a/lib/Catalyst/Authentication/Realm/Progressive.pm
+++ b/lib/Catalyst/Authentication/Realm/Progressive.pm
@@ -143,20 +143,9 @@ sub authenticate {
     return;
 }
 
-## we can not rely on inheriting new() because in this case we do not
-## load a credential or store, which is what new() sets up in the
-## standard realm.  So we have to create our realm object, set our name
-## and return $self in order to avoid nasty warnings.
-
-sub new {
-    my ($class, $realmname, $config, $app) = @_;
-
-    my $self = { config => $config };
-    bless $self, $class;
-
-    $self->name($realmname);
-    return $self;
-}
+## we don't want our own store or credential, so avoid setting them up
+sub setup_store {}
+sub setup_credential {}
 
 =head1 AUTHORS
 

--- a/lib/Catalyst/Plugin/Authentication.pm
+++ b/lib/Catalyst/Plugin/Authentication.pm
@@ -814,6 +814,12 @@ prevent accidental session creation, check if a session already exists with
 if ($c->sessionid) { ... }. If the session doesn't exist, then don't place
 anything in the session to prevent an unecessary session from being created.
 
+=item rotate_session_id
+
+Whether or not to rotate the session ID when authenticating as a new user. This
+mitigates session-fixation attacks (L<CWE-384|https://cwe.mitre.org/data/definitions/384.html>).
+This requires L<Catalyst::Plugin::Session> version 0.25. This value is set to true by default.
+
 =item default_realm
 
 This defines which realm should be used as when no realm is provided to methods

--- a/t/lib/AuthSessionTestApp/Controller/Root.pm
+++ b/t/lib/AuthSessionTestApp/Controller/Root.pm
@@ -72,5 +72,18 @@ sub butterfly : Local {
     ok( !$c->user, "no user object either" );
 }
 
-1;
+sub octopus : Local {
+    my ( $self, $c ) = @_;
 
+    my $session_id = $c->sessionid;
+    ok($session_id, "have session id");
+    ok(!$c->user_exists, "no user exists");
+    ok(!$c->user, "no user yet");
+    ok($c->login( "bar", "s3cr3t" ), "can login with clear");
+    is( $c->user, $AuthSessionTestApp::users->{bar}, "user object is in proper place");
+    my $new_session_id = $c->sessionid;
+    ok($new_session_id, "have session id");
+    isnt($new_session_id, $session_id, "session id has changed");
+}
+
+1;

--- a/t/live_app_session.t
+++ b/t/live_app_session.t
@@ -39,7 +39,7 @@ ok +$res->is_success, 'get ok';
 $res = _request('/yak');
 ok !$res->is_success, 'Not ok, user unable to be resotred == nasal demons';
 
-foreach my $type (qw/ goat fluffy_bunny possum butterfly /) {
+foreach my $type (qw/ goat fluffy_bunny possum butterfly octopus/) {
     $res = _request("/$type");
     ok +$res->is_success, "get $type ok";
 }


### PR DESCRIPTION
Adds a rotate_session_id configuration option, defaulting to true, which will rotate the session id after a successful authentication. This mitigates session fixation attacks.

Some refactoring was needed to make the Realm constructors work properly.